### PR TITLE
Include tidyverse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM r-base:4.1.2
+FROM rocker/tidyverse:4.2.2
 
 RUN apt-get update && \
     apt-get install -y jq && \

--- a/results.json
+++ b/results.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "status": "pass"
+}

--- a/tests/example-success-tidyverse/example-success-tidyverse.R
+++ b/tests/example-success-tidyverse/example-success-tidyverse.R
@@ -1,0 +1,5 @@
+library(tidyverse)
+
+leap <- function(year) {
+  year %% 400 == 0 || (year %% 100 != 0 & year %% 4 == 0)
+}

--- a/tests/example-success-tidyverse/expected_results.json
+++ b/tests/example-success-tidyverse/expected_results.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "status": "pass"
+}

--- a/tests/example-success-tidyverse/test_example-success-tidyverse.R
+++ b/tests/example-success-tidyverse/test_example-success-tidyverse.R
@@ -1,0 +1,26 @@
+source("./example-success-tidyverse.R")
+library(testthat)
+
+context("leap")
+
+test_that("year not divisible by 4: common year", {
+  year <- 2015
+  expect_equal(leap(year), FALSE)
+})
+
+test_that("year divisible by 4, not divisible by 100: leap year", {
+  year <- 2016
+  expect_equal(leap(year), TRUE)
+})
+
+test_that("year divisible by 100, not divisible by 400: common year", {
+  year <- 2100
+  expect_equal(leap(year), FALSE)
+})
+
+test_that("year divisible by 400: leap year", {
+  year <- 2000
+  expect_equal(leap(year), TRUE)
+})
+
+message("All tests passed for exercise: leap")

--- a/tests/example-tidyverse-success/example-tidyverse-success.R
+++ b/tests/example-tidyverse-success/example-tidyverse-success.R
@@ -1,0 +1,5 @@
+library(tidyverse)
+
+leap <- function(year) {
+  year %% 400 == 0 || (year %% 100 != 0 & year %% 4 == 0)
+}

--- a/tests/example-tidyverse-success/expected_results.json
+++ b/tests/example-tidyverse-success/expected_results.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "status": "pass"
+}

--- a/tests/example-tidyverse-success/test_example-tidyverse-success.R
+++ b/tests/example-tidyverse-success/test_example-tidyverse-success.R
@@ -1,0 +1,26 @@
+source("./example-tidyverse-success.R")
+library(testthat)
+
+context("leap")
+
+test_that("year not divisible by 4: common year", {
+  year <- 2015
+  expect_equal(leap(year), FALSE)
+})
+
+test_that("year divisible by 4, not divisible by 100: leap year", {
+  year <- 2016
+  expect_equal(leap(year), TRUE)
+})
+
+test_that("year divisible by 100, not divisible by 400: common year", {
+  year <- 2100
+  expect_equal(leap(year), FALSE)
+})
+
+test_that("year divisible by 400: leap year", {
+  year <- 2000
+  expect_equal(leap(year), TRUE)
+})
+
+message("All tests passed for exercise: leap")


### PR DESCRIPTION
This replaces the base R test runner docker image with the rocker organisations tidyverse image, specifically [4.2.2](https://hub.docker.com/layers/rocker/tidyverse/4.2.2/images/sha256-cb9a8f0bcec6e45e40738b9fd82b38cf1eb5cc496c34a585c3b08dfb0b6b3a51?context=explore) which arose from [this forum discussion](http://forum.exercism.org/t/is-it-possible-to-use-a-dependency-library-module/4218).

This  allows many more packages to be used in the test solution, most notably dplyr, tibble, purrr, stringr and forcats.