### PR TITLE
:construction_worker: Try again with rocker/r-ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-FROM r-base:4.1.2
+FROM rocker/r-ubuntu:22.04
 
-RUN apt-get update && \
-    apt-get install -y jq && \
-    apt-get purge --auto-remove -y && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN Rscript -e 'install.packages("testthat")'
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    jq \
+    r-cran-testthat \
+    r-cran-tidyverse \
+  && apt-get purge --auto-remove -y \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY . /opt/test-runner
 WORKDIR /opt/test-runner

--- a/tests/example-tidyverse-success/example-tidyverse-success.R
+++ b/tests/example-tidyverse-success/example-tidyverse-success.R
@@ -1,0 +1,7 @@
+library(tidyverse)
+library(dplyr)
+
+leap <- function(year) {
+  dplyr::select(mtcars, cyl)
+  year %% 400 == 0 || (year %% 100 != 0 & year %% 4 == 0)
+}

--- a/tests/example-tidyverse-success/expected_results.json
+++ b/tests/example-tidyverse-success/expected_results.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "status": "pass"
+}

--- a/tests/example-tidyverse-success/test_example-tidyverse-success.R
+++ b/tests/example-tidyverse-success/test_example-tidyverse-success.R
@@ -1,0 +1,26 @@
+source("./example-tidyverse-success.R")
+library(testthat)
+
+context("leap")
+
+test_that("year not divisible by 4: common year", {
+  year <- 2015
+  expect_equal(leap(year), FALSE)
+})
+
+test_that("year divisible by 4, not divisible by 100: leap year", {
+  year <- 2016
+  expect_equal(leap(year), TRUE)
+})
+
+test_that("year divisible by 100, not divisible by 400: common year", {
+  year <- 2100
+  expect_equal(leap(year), FALSE)
+})
+
+test_that("year divisible by 400: leap year", {
+  year <- 2000
+  expect_equal(leap(year), TRUE)
+})
+
+message("All tests passed for exercise: leap")


### PR DESCRIPTION
This is based on an image which is close to `r-base`, so it's essentially a version of approach (c) as discussed in #59, but is a little tidier since this image allows for installation of binary R packages as well as dependencies via `apt`, thus avoiding the need to build R packages from source.

Hopefully it works this time!