### PR TITLE
[Docker]: Retooled the Dockerfile to use a base image from r-minimal.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-FROM rocker/tidyverse:4.5.2
+FROM rhub/r-minimal
 
-RUN apt-get update && \
-    apt-get install -y jq && \
-    apt-get purge --auto-remove -y && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk --update add jq
 
-RUN Rscript -e 'install.packages("testthat")'
+RUN installr -d \
+    -t "curl-dev libxml2-dev linux-headers gfortran fontconfig-dev fribidi-dev harfbuzz-dev freetype-dev libpng-dev tiff-dev" \
+    -a "libcurl libxml2 fontconfig fribidi harfbuzz freetype libpng tiff libjpeg icu-libs" \
+    stringr \
+    tidyverse  \
+    testthat
 
 COPY . /opt/test-runner
 WORKDIR /opt/test-runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ RUN apk --update add jq
 RUN installr -d \
     -t "curl-dev libxml2-dev linux-headers gfortran fontconfig-dev fribidi-dev harfbuzz-dev freetype-dev libpng-dev tiff-dev" \
     -a "libcurl libxml2 fontconfig fribidi harfbuzz freetype libpng tiff libjpeg icu-libs" \
-    stringr \
     tidyverse  \
     testthat
 


### PR DESCRIPTION
I **_think_** this succeeds in getting the image down to ~210mb.  But we probably want to do more testing than the tests in `run-tests-in-docker.sh`.

Let me know if there are more libs needed than the ones listed.  More information on `r-minimal` can be found [here](https://github.com/r-hub/r-minimal/tree/main).

Not quite sure it used the latest image which uses R 5.4.2, so we can be explicit about it if needed.